### PR TITLE
Changes to make copy/paste easier

### DIFF
--- a/Install IBM Spectrum Conductor for Containers.md
+++ b/Install IBM Spectrum Conductor for Containers.md
@@ -41,90 +41,90 @@ Installation
 
     1.  Set a password for the root user
 
-        1.  sudo su - \# provide your user password to get to the root shell
+        1.  ```sudo su -``` \# provide your user password to get to the root shell
 
-        2.  passwd \# Set the root password
+        2.  ```passwd``` \# Set the root password
 
 ![alt text](Installation/root-pwd.png "Root password")
 
 
     2.  Enable remote login as root
 
-        1.  sed -I ‘s/prohibit-password/yes/’ /etc/ssh/sshd\_config
+        1.  ```sed -I ‘s/prohibit-password/yes/’ /etc/ssh/sshd_config```
 
-        2.  <img src="media/image3.png" width="624" height="505" />systemctl restart ssh
+        2.  ```systemctl restart ssh```
 
 ![alt text](Installation/remote-login.png "Remote login")
 
 
 2.  Update NTP settings to make sure time stays in sync
 
-    1.  apt-get install -y ntp
+    1.  ```apt-get install -y ntp```
 
     2.  If using an internal NTP server, edit /etc/ntp.conf and add your internal server to the list and then restart the ntp server. In the following configuration, the server is configured to use a local NTP server (ntp.csplab.local) and fall back to public servers if that server is unavailable.
 
 ![alt text](Installation/ntp.png "NTP")
 
 After making configuration changes restart the NTP server with the command:
-> sytemctl retart ntp
+> ```sytemctl retart ntp```
 > To test the status of your NTP servers, use the command:
-> ntpq -p
+> ```ntpq -p```
 
 ![alt text](Installation/ntpq.png "ntpq -p")
 
 
 1.  Update the vm.max\_map\_count setting to 262144:
-    sysctl -w vm.max\_map\_count=262144
+    ```sysctl -w vm.max\_map\_count=262144```
     Make the changes permanent by adding the following line to the bottom of the /etc/sysctl.conf file:
     ![alt text](Installation/sysctl.png "sysctl")
     
     To check the current value use the command:
-    sysctl vm.max\_map\_count
+    ```sysctl vm.max_map_count```
 
 ![alt text](Installation/sysctl-2.png "sysctl-2")
 
 2.  Install docker
 
-    1.  apt-get update
+    1.  ```apt-get update```
 
     2.  Install Linux image extra packages
-        apt-get install -y linux-image-extra-$(uname -r) linux-image-extra-virtual
+        ```apt-get install -y linux-image-extra-$(uname -r) linux-image-extra-virtual```
 
     3.  Install the docker repositories
-        apt-get install -y apt-transport-https ca-certificates curl software-properties-common
+        ```apt-get install -y apt-transport-https ca-certificates curl software-properties-common```
 
     4.  Add Docker’s official GPG key
-        curl -fsSL <https://download.docker.com/linux/ubuntu/gpg> | apt-key add -
+        ```curl -fsSL <https://download.docker.com/linux/ubuntu/gpg> | apt-key add -```
 
     5.  Verify that the key fingerprint is 9DC8 5822 9FC7 DD38 854A E2D8 8D81 803C 0EBF CD88
-        apt-key fingerprint 0EBFCD88
+        ```apt-key fingerprint 0EBFCD88```
 ![alt text](Installation/fingerprint.png "fingerprint")
     6.  Setup the docker stable repository
-        add-apt-repository “deb \[arch=amd64\] <https://download.docker.com/linux/ubuntu> $(lsb\_release -cs) stable”
+        ```add-apt-repository "deb \[arch=amd64\] <https://download.docker.com/linux/ubuntu> $(lsb\_release -cs) stable"```
 
     7.  Install docker
 
-        1.  apt-get update
+        1.  ```apt-get update```
 
-        2.  apt-get install -y docker-ce
+        2.  ```apt-get install -y docker-ce```
 
     8.  Makes sure docker is running
 
-        1.  docker run hello-world
+        1.  ```docker run hello-world```
 
     9.  If this doesn’t work, you will need to do some troubleshooting.
 
 3.  Install docker.py
 
-    1.  apt-get install -y python-setuptools
+    1.  ```apt-get install -y python-setuptools```
 
-    2.  easy\_install pip
+    2.  ```easy_install pip```
 
-    3.  pip install docker-py&gt;=1.7.0
+    3.  ```pip install docker-py>=1.7.0```
 
 4.  Shutdown your VM
 
-    1.  Shutdown -h now
+    1.  ```shutdown -h now```
 
 5.  In the VMware vCenter Web Client convert this VM to a template. We will use this template to provision any additional nodes we need in the environment including additional worker nodes as needed.
     Create new VMs from your new template for each of the nodes in the cluster:

--- a/Install IBM Spectrum Conductor for Containers.md
+++ b/Install IBM Spectrum Conductor for Containers.md
@@ -224,7 +224,7 @@ After making configuration changes restart the NTP server with the command:
 
         1.  ```mesos_enabled: false```
 
-        2.  ```install_docker\_py: false``` \# We already installed this in step 7
+        2.  ```install_docker_py: false``` \# We already installed this in step 7
 
         3.  ```network_type: calico```
             Calico networking uses BGP for routing. Enabling routing between an existing network infrastructure and the cfc cluster requires separate configuration. See Appendix A.
@@ -232,11 +232,11 @@ After making configuration changes restart the NTP server with the command:
         4.  ```network_cidr: 10.1.0.0/16```
             This value must be routable within your network so it cannot overlap any existing subnet.
 
-        5.  Service\_cluster\_ip\_range: 10.0.0.1/24
+        5.  ```service_cluster_ip_range: 10.0.0.1/24```
             This value does not need to be routable, but should not conflict with the network\_cidr range or anything in your existing host network.
             (Interestingly, this subnet is the lowest possible subnet in the 10.x class A private IP range. The subnet starts with .1 because 10.0.0.0 is the subnet name and is not available for assignment.
 
-        6.  Cluster\_domain: cluster.local
+        6.  ```cluster_domain: cluster.local```
             This should be sufficient unless you have other clusters in your network. No two cluster\_domains can be the same.
 
         7.  None of the additional options should be modified

--- a/Install IBM Spectrum Conductor for Containers.md
+++ b/Install IBM Spectrum Conductor for Containers.md
@@ -157,39 +157,36 @@ After making configuration changes restart the NTP server with the command:
     1.  Login as to the boot-master node as root
 
     2.  From root’s home directory execute:
-        ssh-keygen -t rsa -P ‘’ \# Upper case P and two single quotes for no password
+        ```ssh-keygen -t rsa -P ''``` \# Upper case P and two single quotes for no password
         Accept the default location of /root/.ssh/id\_rsa for the new key file
-        Now, executing “ls .ssh” from root’s home directory should show three files: id\_rsa, id\_rsa.pub and known\_hosts
+        Now, executing ```ls .ssh``` from root’s home directory should show three files: ```id_rsa```, ```id_rsa.pub``` and ```known_hosts```
 
-    3.  Copy the resulting is\_rsa key file to each node in the cluster (including the boot-master node on which we are currently operating).
+    3.  Copy the resulting ```id_rsa``` key file to each node in the cluster (including the boot-master node on which we are currently operating).
 
         1.  Copy to the master node (to the current node):
-            ssh-copy-id -i .ssh/id\_rsa <root@172.16.50.255>
-            You will now find that there is a new file called ‘authorized\_keys’ in your .ssh folder which contains the contents of id\_rsa.
+            ```ssh-copy-id -i .ssh/id_rsa root@cfc-proxy```
+            You will now find that there is a new file called ```authorized_keys``` in your .ssh folder which contains the contents of ```id_rsa```.
 
         2.  Repeat for each additional server:
         
-            ssh-copy-id -I .ssh/id\_rsa root@172.16.50.254
+            ```ssh-copy-id -I .ssh/id_rsa root@cfc-worker1```
             
-            ssh-copy-id -I .ssh/id\_rsa root@172.16.50.253
+            ```ssh-copy-id -I .ssh/id_rsa root@cfc-worker2```
             
-            ssh-copy-id -I .ssh/id\_rsa root@172.16.50.252
-            
-            ssh-copy-id -I .ssh/id\_rsa root@172.16.50.251
+            ```ssh-copy-id -I .ssh/id_rsa root@cfc-worker3```
             
 
         3.  When this is complete you should be able to ssh from the boot-master node to each of the other nodes without having to provide a password. You can test this by executing:
         
-            ssh root@172.16.50.255
+            ```ssh root@cfc-proxy```
             
-            ssh root@172.16.50.254
+            ```ssh root@cfc-worker1```
             
-            ssh root@172.16.50.253
+            ```ssh root@cfc-worker2```
             
-            ssh root@172.16.50.252
+            ```ssh root@cfc-worker3```
             
-            ssh root@172.16.50.251
-            
+
             If you cannot gain access via SSH without a password, ensure that you have enabled root login on each VM and have modified /etc/ssh/sshd\_config on each VM to allow remote login.
 
 8.  Your virtual machines are now ready to install CFC and now is a good time to take a snapshot of each VM in the cluster. In the event something goes wrong with the installation you can revert to this snapshot and try it again.[1]

--- a/Install IBM Spectrum Conductor for Containers.md
+++ b/Install IBM Spectrum Conductor for Containers.md
@@ -36,9 +36,6 @@ Installation
 >
 > Initially, configure the server for DHCP (if available). We will assign static IP’s later. If not available assign the static IP of your boot/master server here.
 
-1.  Update /etc/host file with IP addresses and hostnames of all cluster servers
-
-![alt text](Installation/host-file.png "Host file")
 
 1.  Enable root login remotely via ssh
 

--- a/Install IBM Spectrum Conductor for Containers.md
+++ b/Install IBM Spectrum Conductor for Containers.md
@@ -50,9 +50,9 @@ Installation
 
     2.  Enable remote login as root
 
-        1.  ```sed -I ‘s/prohibit-password/yes/’ /etc/ssh/sshd_config```
+        1.  sed -I 's/prohibit-password/yes/' /etc/ssh/sshd_config
 
-        2.  ```systemctl restart ssh```
+        2.  systemctl restart ssh
 
 ![alt text](Installation/remote-login.png "Remote login")
 

--- a/Install IBM Spectrum Conductor for Containers.md
+++ b/Install IBM Spectrum Conductor for Containers.md
@@ -74,7 +74,7 @@ After making configuration changes restart the NTP server with the command:
 
 
 1.  Update the vm.max\_map\_count setting to 262144:
-    ```sysctl -w vm.max\_map\_count=262144```
+    ```sysctl -w vm.max_map_count=262144```
     Make the changes permanent by adding the following line to the bottom of the /etc/sysctl.conf file:
     ![alt text](Installation/sysctl.png "sysctl")
     
@@ -94,13 +94,13 @@ After making configuration changes restart the NTP server with the command:
         ```apt-get install -y apt-transport-https ca-certificates curl software-properties-common```
 
     4.  Add Docker’s official GPG key
-        ```curl -fsSL <https://download.docker.com/linux/ubuntu/gpg> | apt-key add -```
+        ```curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -```
 
     5.  Verify that the key fingerprint is 9DC8 5822 9FC7 DD38 854A E2D8 8D81 803C 0EBF CD88
         ```apt-key fingerprint 0EBFCD88```
 ![alt text](Installation/fingerprint.png "fingerprint")
     6.  Setup the docker stable repository
-        ```add-apt-repository "deb \[arch=amd64\] <https://download.docker.com/linux/ubuntu> $(lsb\_release -cs) stable"```
+        ```add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb\_release -cs) stable"```
 
     7.  Install docker
 

--- a/Install IBM Spectrum Conductor for Containers.md
+++ b/Install IBM Spectrum Conductor for Containers.md
@@ -251,7 +251,7 @@ After making configuration changes restart the NTP server with the command:
     Note that it is normal to occasionally get a “FAILED” message on the screen. This is a process waiting for another process to become available and this only means that it was not available at this check and it will sleep for a time and retry.
 ![alt text](Installation/deployment-1.png "deployment 1")
 ![alt text](Installation/deployment-2.png "deployment 2")
-    Login to your new implementation at <http://172.16.50.255>:8443 with userid of admin and password of admin.
+    Login to your new implementation at <https://172.16.50.255>:8443 with userid of admin and password of admin.
 
 Appendix A
 ==========

--- a/Install IBM Spectrum Conductor for Containers.md
+++ b/Install IBM Spectrum Conductor for Containers.md
@@ -194,7 +194,7 @@ After making configuration changes restart the NTP server with the command:
 9.  Next we need to download the cfc installer docker image.
 
     1.  On the boot-master node as the root user ensure your docker service is running:
-        systemctl status docker
+        ```systemctl status docker```
 ![alt text](Installation/status-docker.png "status docker")
     2.  If the response shows that docker is not running you can start it with the command:
         systemctl start docker
@@ -208,28 +208,28 @@ After making configuration changes restart the NTP server with the command:
         
             cd /opt
         3.  Extract the configuration files into the local directory under the ‘cluster’ subdirectory
-            docker run -e LICENSE=accept –rm -v “$(pwd)”:/data ibmcom/cfc-installer:1.2.0 cp -r cluster /data
+            ```docker run -e LICENSE=accept --rm -v "$(pwd)":/data ibmcom/cfc-installer:1.2.0 cp -r cluster /data```
 
 10. Configure the cfc installer
 
     1.  Modify /opt/cluster/hosts to specify the IP addresses for the VMs in your cluster
     
-    2.  Copy the id\_rsa file created in step 11b over the /opt/cluster/ssh\_key file and ensure its permissions are set to 400.
+    2.  Copy the ```id_rsa``` file created in step 11b over the ```/opt/cluster/ssh_key``` file and ensure its permissions are set to 400.
     
-        cp ~/.ssh/id\_rsa /opt/cluster/ssh\_key
+        ```cp ~/.ssh/id_rsa /opt/cluster/ssh_key```
         
-        chmod 400 /opt/cluster/ssh\_key
+        ```chmod 400 /opt/cluster/ssh_key```
 
     3.  Modify the /opt/cluster/conifg.yaml file to compliment your environment.
 
-        1.  mesos\_enabled: false
+        1.  ```mesos_enabled: false```
 
-        2.  install\_docker\_py: false \# We already installed this in step 7
+        2.  ```install_docker\_py: false``` \# We already installed this in step 7
 
-        3.  network\_type: calico
+        3.  ```network_type: calico```
             Calico networking uses BGP for routing. Enabling routing between an existing network infrastructure and the cfc cluster requires separate configuration. See Appendix A.
 
-        4.  network\_cidr: 10.1.0.0/16
+        4.  ```network_cidr: 10.1.0.0/16```
             This value must be routable within your network so it cannot overlap any existing subnet.
 
         5.  Service\_cluster\_ip\_range: 10.0.0.1/24
@@ -245,7 +245,7 @@ After making configuration changes restart the NTP server with the command:
 
     cd /opt/cluster
     
-    docker run -e LICENSE=accept –net=host –rm -t -v “$(pwd)”:/installer/cluster ibmcom/cfc-installer:1.2.0 install
+    ```docker run -e LICENSE=accept --net=host --rm -t -v "$(pwd)":/installer/cluster ibmcom/cfc-installer:1.2.0 install```
 
 12. About 10 minutes later you should have a deployed IBM Spectrum Conductor for Containers implementation.
     Note that it is normal to occasionally get a “FAILED” message on the screen. This is a process waiting for another process to become available and this only means that it was not available at this check and it will sleep for a time and retry.


### PR DESCRIPTION
Seems a lot of the text has been copied from a word document, so double quotes ", double dash -- etc are not formatted correctly causing errors when copy/pasting from instructions.

Also using MarkDown code blocks to highlight commands that are to be executed. This also removes the need to escape and html encode certain characters