### PR TITLE
PVC connecting to Storage Class is named incorrect

### DIFF
--- a/Install_OCP_4.x.md
+++ b/Install_OCP_4.x.md
@@ -1094,7 +1094,7 @@ Create a PVC to be consumed by the image registry (pvc.yaml)
       requests:
         storage: 100Gi
     persistentVolumeReclaimPolicy: Retain
-    storageClassName: csi-cephfs
+    storageClassName: rook-cephfs
   ```
 
 Deploy the PVC:


### PR DESCRIPTION
PVC connecting to Storage Class is named incorrectly causing an unbound error on the PVC