### PR TITLE
Added temporary fix for the rook-ceph install

### DIFF
--- a/Install_OCP_4.x.md
+++ b/Install_OCP_4.x.md
@@ -868,6 +868,13 @@ Clone the rook project from github
   cd /opt
   git clone https://github.com/rook/rook.git
   ```
+* --Temporary--
+*And checkout the revision "3d5776f"*
+```
+git checkout 3d5776f
+```
+
+
 
   You should now have a subdirectory under /opt named `rook`.
 
@@ -1105,6 +1112,8 @@ Create a PVC to be consumed by the image registry (pvc.yaml)
     persistentVolumeReclaimPolicy: Retain
     storageClassName: rook-cephfs
   ```
+* --Temporary--
+On the last line, replace `rook-cephfs` by `csi-cephfs`
 
 Deploy the PVC:
 


### PR DESCRIPTION
- Added a temporary fix for the installation of rook-ceph (current instructions not compatible with the latest commits on https://github.com/rook/rook.git)
- There are 2 changes, they can be found by searching for the string "--Temporary--"
- Credits to Andrew Suh for sharing the fix